### PR TITLE
Build docker container

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,46 @@
+name: Publish container
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1-slim-bookworm as build
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && apt-get clean
+
+WORKDIR /usr/src/admarus
+COPY . .
+
+RUN cd daemon && \
+    cargo build --release && \
+    mv ../target/release/admarusd /usr/local/bin/admarusd && \
+    cd ../../ && \
+    rm -rf admarus
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y libssl ca-certificates && apt-get clean
+
+COPY --from=build /usr/local/bin/admarusd /usr/local/bin/admarusd
+
+EXPOSE 4002
+EXPOSE 5002
+
+ENTRYPOINT ["/usr/local/bin/admarusd"]


### PR DESCRIPTION
Closes #97 

- Sets up a `Dockerfile` with an appropriate configuration to run the (non-database-lmdb) version of `admarusd`
- Includes a Github Actions script to auto-build a Debian-based docker container on every push to the `master` branch — for both ARM64 and AMD64. The compute time to build the images, and storage space for storing them is free for public/open source projects on Github.

I have this set up on my fork, so you can run the following right now (naturally, once this PR is merged, the docker container used should be `ghcr.io/Mubelotix/admarus:master`):

```bash
docker run --network=host ghcr.io/jphastings/admarus:master \
  --ipfs-rpc=http://host.docker.internal:5001 \
  --external-addrs=/ip4/$(curl -s https://api.ipify.org)/tcp/4002 \
  --external-addrs=/ip6/$(curl -s https://api64.ipify.org)/tcp/4002 \
```

(Note that I'm using `api.ipify.org` to get the local external IP address at execute time, but anyone running this would want to hard-code their IP address, or external hostname, as [the guide](https://github.com/Mubelotix/admarus/wiki/Installation#port-forwarding) describes)

## Notes

### In-memory cache

This docker build currently _doesn't_ contain a build with the `database-lmdb` feature. While it's possible to compile two different versions of `admarusd` and store them in this image, I'd need to implement a bash script to accept a flag that switches between the two, and passes other flags on to `admarusd`:

```sh
docker run admarus --use-database-lmdb # Run with database-lmdb feature
docker run admarus # Run without database-lmdb feature
```

Though this is effective, this could get very confusing for people _not_ using docker, when that flag doesn't exist for them. If it's possible to reconfigure admarusd's code so that using a the DB can be configured at runtime, this would allow the docker container and daemon to have the same argument flags, and reduce confusion.

### Debian & container size

This is a "multistage" container — the first stage builds admarusd within a container that has all the rust & development libraries installed (which total 2.6GB), and a second container that copies the `admarusd` binary to a slimmed down Debian Bookworm container that only contains root CA Certificates and the OpenSSL dynamic libraries (which totals 160MB).

This could be an order of magnitude smaller again (~12MB) if we didn't need the whole of the Debian OS, in order to have the OpenSSL runtime. @Mubelotix, if you're able to migrate from using OpenSSL to [rustls](https://github.com/rustls/rustls), then you'd need no OpenSSL linked library at runtime, and no C libraries at all, making cross-compilation much simpler too.

### `--ipfs-rpc=http://host.docker.internal:5001`

This command assumes IPFS is running on your host machine. Any hostname can be used here as usual, but (depending on your docker networking mode, see below) you may need to remember that loopback addresses (eg. 12.0.0.1) point to the _container running admarusd_, not to your computer running docker. `host.docker.internal` is a magic hostname that points to your host machine, even on more complex setups like on macos, where docker is _actually_ running inside a VM.

### `--network=host`

The command I wrote out above puts Admarus on the _host_ network, rather than exposing particular ports (ie. `docker run -p 4002:4002 -p 5002:5002 ghcr.io/jphastings/admarus:master`). For some reason bridging like this doesn't seem to work at the moment (Running `curl http://127.0.0.1:5002/version` returns an empty response instead of a version number).

I'll keep looking into this, as something isn't quite right (perhaps there are other ports that need to be open?) but running on host netwokring is good enough for early builds here.

### `admarus:master`

The docker image name is currently derived from the branch it builds from (`master`), but docker containers usually also build git versions into their labels too. If Admarus were to have [semver](https://semver.org) git tags like `v0.1.2`, then I would update this PR to build:
- A `master` label, for every push to the master branch
- A `0` label, for every git commit with a tag starting `v0` (ie. the most recent of `v0.1.0`, `v0.2.1`, etc)
- A `0.1` label, for every git commit with a tag starting `v0.1` (ie. the most recent of `v0.1.0`, `v0.1.1`, etc)
- A `0.1.2` label, for the git commit with the tag `v0.1.2`

We'd then also choose which of these we'd want to call `latest` (the latest tagged build, or the latest `master` build) — as `latest` is the default label chosen by docker.

This would mean that users of the docker images can stay up to date using semantic versioning, or pin to a specific version as needed.